### PR TITLE
Fixing error message null for retry count

### DIFF
--- a/src/main/java/org/mifos/connector/notification/sms/delivery/DeliveryCallbackRoute.java
+++ b/src/main/java/org/mifos/connector/notification/sms/delivery/DeliveryCallbackRoute.java
@@ -91,13 +91,13 @@ public class DeliveryCallbackRoute extends RouteBuilder{
                             boolean hasError = jsonObject.get("hasError").getAsBoolean();
                             if(!hasError) {
                                 if (jsonObject.has("errorMessage")) {
-                                    if(jsonObject.get("errorMessage") != null) {
-                                        logger.info("Error encountered: " + jsonObject.get("errorMessage"));
-                                        exchange.setProperty(DELIVERY_ERROR_INFORMATION, jsonObject.get("errorMessage"));
+                                    if(jsonObject.get("errorMessage").isJsonNull()) {
+                                        logger.info("Still Pending, will retry");}
+                                    else{
+                                        logger.info("Error encountered: " + jsonObject.get("errorMessage").getAsString());
+                                        exchange.setProperty(DELIVERY_ERROR_INFORMATION, jsonObject.get("errorMessage").getAsString());
                                         exchange.setProperty(MESSAGE_DELIVERY_STATUS, false);
                                     }
-                                } else {
-                                    logger.info("Still Pending, will retry");
                                 }
                             }
                         }
@@ -183,13 +183,13 @@ public class DeliveryCallbackRoute extends RouteBuilder{
                         boolean hasError = jsonObject.get("hasError").getAsBoolean();
                         if(!hasError) {
                             if (jsonObject.has("errorMessage")) {
-                                if(jsonObject.get("errorMessage") != null) {
-                                    logger.info("Error encountered: " + jsonObject.get("errorMessage"));
-                                    exchange.setProperty(DELIVERY_ERROR_INFORMATION, jsonObject.get("errorMessage"));
+                                if(jsonObject.get("errorMessage").isJsonNull()) {
+                                    logger.info("Still Pending, will retry");}
+                                else{
+                                    logger.info("Error encountered: " + jsonObject.get("errorMessage").getAsString());
+                                    exchange.setProperty(DELIVERY_ERROR_INFORMATION, jsonObject.get("errorMessage").getAsString());
                                     exchange.setProperty(MESSAGE_DELIVERY_STATUS, false);
                                 }
-                            } else {
-                                logger.info("Still Pending, will retry");
                             }
                         }
                     }


### PR DESCRIPTION
Fixing json null error. 
On adding  jsonObject.get(“errorMessage”) != null the code still returned a json null error so replaced the logic with jsonObject.get("errorMessage").isJsonNull()

Please Review and Merge

@SubhamPramanik @avikganguly01 