### PR TITLE
Updating the failure message

### DIFF
--- a/src/main/java/org/mifos/connector/notification/sms/dto/MessageCreationDto.java
+++ b/src/main/java/org/mifos/connector/notification/sms/dto/MessageCreationDto.java
@@ -35,7 +35,13 @@ public class MessageCreationDto {
                 .atZone(ZoneId.systemDefault()).toLocalDate();
         String amount = (String) variables.get(AMOUNT);
         Exchange exchange = new DefaultExchange(camelContext);
-        exchange.setProperty(CORRELATION_ID, transactionId);
+
+        if(variables.containsKey(SERVER_TRANSACTION_RECEIPT_NUMBER)){
+            exchange.setProperty(CORRELATION_ID, variables.get(SERVER_TRANSACTION_RECEIPT_NUMBER).toString());
+        }
+        else {
+            exchange.setProperty(CORRELATION_ID, transactionId);
+        }
         exchange.setProperty(DATE, localDate);
         exchange.setProperty(ACCOUNT_ID,account);
         exchange.setProperty(TRANSACTION_AMOUNT,amount);

--- a/src/main/java/org/mifos/connector/notification/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/notification/zeebe/ZeebeVariables.java
@@ -19,4 +19,5 @@ public class ZeebeVariables {
     public static final String ACCOUNT = "accountId";
     public static final String AMOUNT = "amount";
     public static final String DELIVERY_ERROR_MESSAGE = "deliveryErrorMessage";
+    public static final String SERVER_TRANSACTION_RECEIPT_NUMBER = "mpesaReceiptNumber";
 }


### PR DESCRIPTION
Logic to address: 

Use mpesaReceiptNumber (if it's not null) instead of mpesaTransactionId for sending out notifications.


@avikganguly01 