### PR TITLE
Bug fix for removing redundant code

### DIFF
--- a/src/main/java/org/mifos/connector/notification/zeebe/ZeebeWorkers.java
+++ b/src/main/java/org/mifos/connector/notification/zeebe/ZeebeWorkers.java
@@ -90,9 +90,6 @@ public class ZeebeWorkers {
                     logger.info("Job '{}' started from process '{}' with key {}", job.getType(), job.getBpmnProcessId(), job.getKey());
 
                     Map<String, Object> variables = job.getVariablesAsMap();
-                    TransactionChannelCollectionRequestDTO channelRequest = objectMapper.readValue(
-                            (String) variables.get("channelRequest"), TransactionChannelCollectionRequestDTO .class);
-
                     Exchange exchange = new DefaultExchange(camelContext);
                     exchange.setProperty(MOBILE_NUMBER,variables.get(PHONE_NUMBER));
                     exchange.setProperty(CORRELATION_ID, variables.get(TRANSACTION_ID));


### PR DESCRIPTION
This fixes the following issue: 

1400 txns failed to send failure notifications - "errorMessage": "com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value. 


@avikganguly01 : Please review and merge


